### PR TITLE
Prevent creation of duplicate communities

### DIFF
--- a/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/community/controllers/CommunityOwnerController.java
+++ b/src/main/java/com/sublinks/sublinksapi/api/lemmy/v3/community/controllers/CommunityOwnerController.java
@@ -111,6 +111,13 @@ public class CommunityOwnerController extends AbstractLemmyApiController {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "community_blocked_by_slur_filter");
     }
 
+    // Prevent users from creating duplicate communities
+    final Optional<Community> oldCommunity = Optional.ofNullable(
+        communityRepository.findCommunityByIsLocalTrueAndTitleSlug(slugUtil.stringToSlug(createCommunityForm.name())));
+    if (oldCommunity.isPresent()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "community_already_exists");
+    }
+
     try {
       String censorText = slurFilterService.censorText(createCommunityForm.name());
       // We dont want censored slugs.... like c/#####communitytest

--- a/src/main/java/com/sublinks/sublinksapi/community/repositories/CommunityRepository.java
+++ b/src/main/java/com/sublinks/sublinksapi/community/repositories/CommunityRepository.java
@@ -8,5 +8,7 @@ public interface CommunityRepository extends JpaRepository<Community, Long>,
 
   Community findCommunityByIdOrTitleSlug(Long id, String titleSlug);
 
+  Community findCommunityByIsLocalTrueAndTitleSlug(String titleSlug);
+
   Community findCommunityByTitleSlug(String titleSlug);
 }


### PR DESCRIPTION
This fixes a bug in which users are able to create communities when a local community with the same url already exists.